### PR TITLE
Interval search (#12)

### DIFF
--- a/Morpheus/Morpheus/Exporters.cs
+++ b/Morpheus/Morpheus/Exporters.cs
@@ -46,7 +46,7 @@ namespace Morpheus
             Protease protease, int maximumMissedCleavages, InitiatorMethionineBehavior initiatorMethionineBehavior,
             IEnumerable<Modification> fixedModifications, string fixedModificationsString, IEnumerable<Modification> variableModifications, string variableModificationsString, int maximumVariableModificationIsoforms,
             MassTolerance precursorMassTolerance, MassType precursorMassType,
-            bool precursorMonoisotopicPeakCorrection, int minimumPrecursorMonoisotopicPeakOffset, int maximumPrecursorMonoisotopicPeakOffset,
+            List<double> massErrors,
             MassTolerance productMassTolerance, MassType productMassType,
             double maximumFalseDiscoveryRate, bool considerModifiedFormsAsUniquePeptides,
             int maximumThreads, bool minimizeMemoryUsage,
@@ -208,8 +208,8 @@ namespace Morpheus
                 output.WriteAttributeString("value", '±' + precursorMassTolerance.Value.ToString(CultureInfo.InvariantCulture) + ' ' + precursorMassTolerance.Units.ToString() + " (" + precursorMassType.ToString().ToLower() + ')');
                 output.WriteEndElement();  // parameter
                 output.WriteStartElement("parameter");
-                output.WriteAttributeString("name", "Precursor Monoisotopic Peak Correction");
-                output.WriteAttributeString("value", (precursorMonoisotopicPeakCorrection ? minimumPrecursorMonoisotopicPeakOffset.ToString("+0;-0;0") + ".." + maximumPrecursorMonoisotopicPeakOffset.ToString("+0;-0;0") : "disabled"));
+                output.WriteAttributeString("name", "Mass errors accepted");
+                output.WriteAttributeString("value", string.Join(", ", massErrors));
                 output.WriteEndElement();  // parameter
                 output.WriteStartElement("parameter");
                 output.WriteAttributeString("name", "Product Mass Tolerance");
@@ -325,7 +325,7 @@ namespace Morpheus
             Protease protease, int maximumMissedCleavages, InitiatorMethionineBehavior initiatorMethionineBehavior,
             IEnumerable<Modification> fixedModifications, IEnumerable<Modification> variableModifications, int maximumVariableModificationIsoforms,
             MassTolerance precursorMassTolerance, MassType precursorMassType,
-            bool precursorMonoisotopicPeakCorrection, int minimumPrecursorMonoisotopicPeakOffset, int maximumPrecursorMonoisotopicPeakOffset,
+            List<double> massErrors,
             MassTolerance productMassTolerance, MassType productMassType,
             double maximumFalseDiscoveryRate, bool considerModifiedFormsAsUniquePeptides,
             int maximumThreads, bool minimizeMemoryUsage,
@@ -606,16 +606,8 @@ namespace Morpheus
                 output.WriteAttributeString("value", maximumVariableModificationIsoforms.ToString());
                 output.WriteEndElement();  // userParam
                 output.WriteStartElement("userParam");
-                output.WriteAttributeString("name", "Precursor Monoisotopic Peak Correction Enabled");
-                output.WriteAttributeString("value", precursorMonoisotopicPeakCorrection.ToString().ToLower());
-                output.WriteEndElement();  // userParam
-                output.WriteStartElement("userParam");
-                output.WriteAttributeString("name", "Minimum Precursor Monoisotopic Peak Correction Offset");
-                output.WriteAttributeString("value", precursorMonoisotopicPeakCorrection ? minimumPrecursorMonoisotopicPeakOffset.ToString() : "n/a");
-                output.WriteEndElement();  // userParam
-                output.WriteStartElement("userParam");
-                output.WriteAttributeString("name", "Maximum Precursor Monoisotopic Peak Correction Offset");
-                output.WriteAttributeString("value", precursorMonoisotopicPeakCorrection ? maximumPrecursorMonoisotopicPeakOffset.ToString() : "n/a");
+                output.WriteAttributeString("name", "Mass errors accepted");
+                output.WriteAttributeString("value", string.Join(", ", massErrors));
                 output.WriteEndElement();  // userParam
                 output.WriteStartElement("userParam");
                 output.WriteAttributeString("name", "Consider Modified Forms as Unique Peptides");

--- a/Morpheus/Morpheus/TandemMassSpectra.cs
+++ b/Morpheus/Morpheus/TandemMassSpectra.cs
@@ -28,34 +28,35 @@ namespace Morpheus
             UpdateProgress?.Invoke(null, e);
         }
 
-        public IEnumerable<TandemMassSpectrum> GetTandemMassSpectraInMassRange(double precursorMass, MassTolerance precursorMassTolerance)
+
+        internal IEnumerable<TandemMassSpectrum> GetTandemMassSpectraInIntervals(List<double> precursorMasses, MassTolerance precursorMassTolerance)
         {
-            return GetTandemMassSpectraInMassRange(precursorMass, precursorMassTolerance, 0, 0);
+            foreach (var precursorMass in precursorMasses)
+            {
+                foreach (var b in GetTandemMassSpectraInMassRange(precursorMass, precursorMassTolerance))
+                {
+                    yield return b;
+                }
+            }
         }
 
-        public IEnumerable<TandemMassSpectrum> GetTandemMassSpectraInMassRange(double precursorMass, MassTolerance precursorMassTolerance,
-            int minimumMonoisotopicPeakOffset, int maximumMonoisotopicPeakOffset)
+        public IEnumerable<TandemMassSpectrum> GetTandemMassSpectraInMassRange(double precursorMass, MassTolerance precursorMassTolerance)
         {
-            for(int i = minimumMonoisotopicPeakOffset; i <= maximumMonoisotopicPeakOffset; i++)
+            double minimum_precursor_mass = precursorMass - precursorMassTolerance;
+            double maximum_precursor_mass = precursorMass + precursorMassTolerance;
+
+            int index = BinarySearch(NextHigherDouble(maximum_precursor_mass));
+            if(index == Count)
             {
-                double precursor_mass = precursorMass + i * Constants.C12_C13_MASS_DIFFERENCE;
-
-                double minimum_precursor_mass = precursor_mass - precursorMassTolerance;
-                double maximum_precursor_mass = precursor_mass + precursorMassTolerance;
-
-                int index = BinarySearch(NextHigherDouble(maximum_precursor_mass));
-                if(index == Count)
+                index--;
+            }
+            while(index >= 0 && this[index].PrecursorMass >= minimum_precursor_mass)
+            {
+                if(this[index].PrecursorMass <= maximum_precursor_mass)
                 {
-                    index--;
+                    yield return this[index];
                 }
-                while(index >= 0 && this[index].PrecursorMass >= minimum_precursor_mass)
-                {
-                    if(this[index].PrecursorMass <= maximum_precursor_mass)
-                    {
-                        yield return this[index];
-                    }
-                    index--;
-                }
+                index--;
             }
         }
 

--- a/Morpheus/Morpheus/command line/Program.cs
+++ b/Morpheus/Morpheus/command line/Program.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 
 namespace Morpheus
@@ -141,20 +142,10 @@ namespace Morpheus
                 {
                     precursor_mass_type = (MassType)Enum.Parse(typeof(MassType), arguments["precmt"], true);
                 }
-                bool prec_mono_correction = false;
-                if(arguments["pmc"] != null)
+                List<double> massErrors = new List<double>() { 0 };
+                if (arguments["masserrors"] != null)
                 {
-                    prec_mono_correction = bool.Parse(arguments["pmc"]);
-                }
-                int min_prec_mono_offset = -3;
-                if(arguments["minpmo"] != null)
-                {
-                    min_prec_mono_offset = int.Parse(arguments["minpmo"]);
-                }
-                int max_prec_mono_offset = 1;
-                if(arguments["maxpmo"] != null)
-                {
-                    max_prec_mono_offset = int.Parse(arguments["maxpmo"]);
+                    massErrors = arguments["masserrors"].Split(',').Select(double.Parse).ToList();
                 }
                 double product_mass_tolerance_value = 0.015;
                 if(arguments["prodmtv"] != null)
@@ -206,7 +197,7 @@ namespace Morpheus
                     protease, max_missed_cleavages, initiator_methionine_behavior,
                     fixed_mods, variable_mods, max_variable_mod_isoforms_per_peptide,
                     precursor_mass_tolerance, precursor_mass_type,
-                    prec_mono_correction, min_prec_mono_offset, max_prec_mono_offset,
+                    massErrors,
                     product_mass_tolerance, product_mass_type,
                     max_fdr, consider_mods_unique,
                     max_threads, minimize_memory_usage,

--- a/Morpheus/Morpheus/frmMain.Designer.cs
+++ b/Morpheus/Morpheus/frmMain.Designer.cs
@@ -47,6 +47,8 @@
             this.label9 = new System.Windows.Forms.Label();
             this.fbdOutput = new System.Windows.Forms.FolderBrowserDialog();
             this.pnlMain = new System.Windows.Forms.Panel();
+            this.massErrorsTextBox = new System.Windows.Forms.TextBox();
+            this.massErrorsLabel = new System.Windows.Forms.Label();
             this.chkMinimizeMemoryUsage = new System.Windows.Forms.CheckBox();
             this.groupBox3 = new System.Windows.Forms.GroupBox();
             this.chkDeisotope = new System.Windows.Forms.CheckBox();
@@ -66,10 +68,6 @@
             this.numMaximumAssumedPrecursorChargeState = new System.Windows.Forms.NumericUpDown();
             this.numMaxThreads = new System.Windows.Forms.NumericUpDown();
             this.label19 = new System.Windows.Forms.Label();
-            this.chkPrecursorMonoisotopicPeakCorrection = new System.Windows.Forms.CheckBox();
-            this.label20 = new System.Windows.Forms.Label();
-            this.numMaxPrecursorMonoPeakOffset = new System.Windows.Forms.NumericUpDown();
-            this.numMinPrecursorMonoPeakOffset = new System.Windows.Forms.NumericUpDown();
             this.chkOnTheFlyDecoys = new System.Windows.Forms.CheckBox();
             this.chkConsiderModifiedUnique = new System.Windows.Forms.CheckBox();
             this.numMaxVariableModIsoforms = new System.Windows.Forms.NumericUpDown();
@@ -115,8 +113,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.numMinimumAssumedPrecursorChargeState)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numMaximumAssumedPrecursorChargeState)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numMaxThreads)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numMaxPrecursorMonoPeakOffset)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numMinPrecursorMonoPeakOffset)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numMaxVariableModIsoforms)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numProductMassTolerance)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numPrecursorMassTolerance)).BeginInit();
@@ -279,6 +275,8 @@
             // 
             // pnlMain
             // 
+            this.pnlMain.Controls.Add(this.massErrorsTextBox);
+            this.pnlMain.Controls.Add(this.massErrorsLabel);
             this.pnlMain.Controls.Add(this.chkMinimizeMemoryUsage);
             this.pnlMain.Controls.Add(this.groupBox3);
             this.pnlMain.Controls.Add(this.groupBox2);
@@ -287,10 +285,6 @@
             this.pnlMain.Controls.Add(this.groupBox1);
             this.pnlMain.Controls.Add(this.numMaxThreads);
             this.pnlMain.Controls.Add(this.label19);
-            this.pnlMain.Controls.Add(this.chkPrecursorMonoisotopicPeakCorrection);
-            this.pnlMain.Controls.Add(this.label20);
-            this.pnlMain.Controls.Add(this.numMaxPrecursorMonoPeakOffset);
-            this.pnlMain.Controls.Add(this.numMinPrecursorMonoPeakOffset);
             this.pnlMain.Controls.Add(this.chkOnTheFlyDecoys);
             this.pnlMain.Controls.Add(this.chkConsiderModifiedUnique);
             this.pnlMain.Controls.Add(this.numMaxVariableModIsoforms);
@@ -332,6 +326,24 @@
             this.pnlMain.Name = "pnlMain";
             this.pnlMain.Size = new System.Drawing.Size(712, 723);
             this.pnlMain.TabIndex = 2;
+            // 
+            // massErrorsTextBox
+            // 
+            this.massErrorsTextBox.Location = new System.Drawing.Point(443, 487);
+            this.massErrorsTextBox.Name = "massErrorsTextBox";
+            this.massErrorsTextBox.Size = new System.Drawing.Size(261, 20);
+            this.massErrorsTextBox.TabIndex = 53;
+            this.massErrorsTextBox.Text = "0";
+            this.massErrorsTextBox.TextChanged += new System.EventHandler(this.ResetProgressBar);
+            // 
+            // massErrorsLabel
+            // 
+            this.massErrorsLabel.AutoSize = true;
+            this.massErrorsLabel.Location = new System.Drawing.Point(438, 468);
+            this.massErrorsLabel.Name = "massErrorsLabel";
+            this.massErrorsLabel.Size = new System.Drawing.Size(112, 13);
+            this.massErrorsLabel.TabIndex = 52;
+            this.massErrorsLabel.Text = "Mass errors to accept:";
             // 
             // chkMinimizeMemoryUsage
             // 
@@ -584,75 +596,6 @@
             this.label19.Size = new System.Drawing.Size(93, 13);
             this.label19.TabIndex = 43;
             this.label19.Text = "Maximum Threads";
-            // 
-            // chkPrecursorMonoisotopicPeakCorrection
-            // 
-            this.chkPrecursorMonoisotopicPeakCorrection.AutoSize = true;
-            this.chkPrecursorMonoisotopicPeakCorrection.Location = new System.Drawing.Point(441, 471);
-            this.chkPrecursorMonoisotopicPeakCorrection.Name = "chkPrecursorMonoisotopicPeakCorrection";
-            this.chkPrecursorMonoisotopicPeakCorrection.Size = new System.Drawing.Size(216, 17);
-            this.chkPrecursorMonoisotopicPeakCorrection.TabIndex = 26;
-            this.chkPrecursorMonoisotopicPeakCorrection.Text = "Precursor Monoisotopic Peak Correction";
-            this.chkPrecursorMonoisotopicPeakCorrection.UseVisualStyleBackColor = true;
-            this.chkPrecursorMonoisotopicPeakCorrection.CheckedChanged += new System.EventHandler(this.chkMonoisotopicPeakCorrection_CheckedChanged);
-            // 
-            // label20
-            // 
-            this.label20.AutoSize = true;
-            this.label20.Enabled = false;
-            this.label20.Location = new System.Drawing.Point(500, 496);
-            this.label20.Name = "label20";
-            this.label20.Size = new System.Drawing.Size(16, 13);
-            this.label20.TabIndex = 28;
-            this.label20.Text = "to";
-            // 
-            // numMaxPrecursorMonoPeakOffset
-            // 
-            this.numMaxPrecursorMonoPeakOffset.Enabled = false;
-            this.numMaxPrecursorMonoPeakOffset.Location = new System.Drawing.Point(522, 494);
-            this.numMaxPrecursorMonoPeakOffset.Maximum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.numMaxPrecursorMonoPeakOffset.Minimum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            -2147483648});
-            this.numMaxPrecursorMonoPeakOffset.Name = "numMaxPrecursorMonoPeakOffset";
-            this.numMaxPrecursorMonoPeakOffset.Size = new System.Drawing.Size(54, 20);
-            this.numMaxPrecursorMonoPeakOffset.TabIndex = 29;
-            this.numMaxPrecursorMonoPeakOffset.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.numMaxPrecursorMonoPeakOffset.ValueChanged += new System.EventHandler(this.ResetProgressBar);
-            // 
-            // numMinPrecursorMonoPeakOffset
-            // 
-            this.numMinPrecursorMonoPeakOffset.Enabled = false;
-            this.numMinPrecursorMonoPeakOffset.Location = new System.Drawing.Point(440, 494);
-            this.numMinPrecursorMonoPeakOffset.Maximum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.numMinPrecursorMonoPeakOffset.Minimum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            -2147483648});
-            this.numMinPrecursorMonoPeakOffset.Name = "numMinPrecursorMonoPeakOffset";
-            this.numMinPrecursorMonoPeakOffset.Size = new System.Drawing.Size(54, 20);
-            this.numMinPrecursorMonoPeakOffset.TabIndex = 27;
-            this.numMinPrecursorMonoPeakOffset.Value = new decimal(new int[] {
-            3,
-            0,
-            0,
-            -2147483648});
-            this.numMinPrecursorMonoPeakOffset.ValueChanged += new System.EventHandler(this.ResetProgressBar);
             // 
             // chkOnTheFlyDecoys
             // 
@@ -1027,8 +970,6 @@
             ((System.ComponentModel.ISupportInitialize)(this.numMinimumAssumedPrecursorChargeState)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numMaximumAssumedPrecursorChargeState)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numMaxThreads)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numMaxPrecursorMonoPeakOffset)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numMinPrecursorMonoPeakOffset)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numMaxVariableModIsoforms)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numProductMassTolerance)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numPrecursorMassTolerance)).EndInit();
@@ -1093,10 +1034,6 @@
         private System.Windows.Forms.NumericUpDown numMaxVariableModIsoforms;
         private System.Windows.Forms.CheckBox chkConsiderModifiedUnique;
         private System.Windows.Forms.CheckBox chkOnTheFlyDecoys;
-        private System.Windows.Forms.Label label20;
-        private System.Windows.Forms.NumericUpDown numMaxPrecursorMonoPeakOffset;
-        private System.Windows.Forms.NumericUpDown numMinPrecursorMonoPeakOffset;
-        private System.Windows.Forms.CheckBox chkPrecursorMonoisotopicPeakCorrection;
         private System.Windows.Forms.NumericUpDown numMaxThreads;
         private System.Windows.Forms.Label label19;
         private System.Windows.Forms.GroupBox groupBox3;
@@ -1118,5 +1055,7 @@
         private System.Windows.Forms.CheckBox chkMinimizeMemoryUsage;
         private System.ComponentModel.BackgroundWorker backgroundWorker1;
         private System.Windows.Forms.Label label21;
+        private System.Windows.Forms.TextBox massErrorsTextBox;
+        private System.Windows.Forms.Label massErrorsLabel;
     }
 }

--- a/Morpheus/Morpheus/frmMain.cs
+++ b/Morpheus/Morpheus/frmMain.cs
@@ -171,17 +171,8 @@ namespace Morpheus
                                 case "Precursor Mass Type":
                                     cboPrecursorMassType.SelectedIndex = (int)Enum.Parse(typeof(MassType), value, true);
                                     break;
-                                case "Precursor Monoisotopic Peak Correction":
-                                    if(cboPrecursorMassType.SelectedIndex == (int)MassType.Monoisotopic)
-                                    {
-                                        chkPrecursorMonoisotopicPeakCorrection.Checked = bool.Parse(value);
-                                    }
-                                    break;
-                                case "Minimum Precursor Offset":
-                                    numMinPrecursorMonoPeakOffset.Value = int.Parse(value);
-                                    break;
-                                case "Maximum Precursor Offset":
-                                    numMaxPrecursorMonoPeakOffset.Value = int.Parse(value);
+                                case "Mass errors accepted":
+                                    massErrorsTextBox.Text = value;
                                     break;
                                 case "Product Mass Tolerance":
                                     numProductMassTolerance.Value = decimal.Parse(value, CultureInfo.InvariantCulture);
@@ -563,41 +554,6 @@ namespace Morpheus
 
         private void cboPrecursorMassType_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if((MassType)cboPrecursorMassType.SelectedIndex == MassType.Monoisotopic)
-            {
-                chkPrecursorMonoisotopicPeakCorrection.Enabled = true;
-                if(chkPrecursorMonoisotopicPeakCorrection.Checked)
-                {
-                    numMinPrecursorMonoPeakOffset.Enabled = true;
-                    label20.Enabled = true;
-                    numMaxPrecursorMonoPeakOffset.Enabled = true;
-                }
-            }
-            else
-            {
-                chkPrecursorMonoisotopicPeakCorrection.Enabled = false;
-                chkPrecursorMonoisotopicPeakCorrection.Checked = false;
-                numMinPrecursorMonoPeakOffset.Enabled = false;
-                label20.Enabled = false;
-                numMaxPrecursorMonoPeakOffset.Enabled = false;
-            }
-            tspbProgress.Value = tspbProgress.Minimum;
-        }
-
-        private void chkMonoisotopicPeakCorrection_CheckedChanged(object sender, EventArgs e)
-        {
-            if(chkPrecursorMonoisotopicPeakCorrection.Checked)
-            {
-                numMinPrecursorMonoPeakOffset.Enabled = true;
-                label20.Enabled = true;
-                numMaxPrecursorMonoPeakOffset.Enabled = true;
-            }
-            else
-            {
-                numMinPrecursorMonoPeakOffset.Enabled = false;
-                label20.Enabled = false;
-                numMaxPrecursorMonoPeakOffset.Enabled = false;
-            }
             tspbProgress.Value = tspbProgress.Minimum;
         }
 
@@ -683,9 +639,7 @@ namespace Morpheus
             }
             MassTolerance precursor_mass_tolerance = new MassTolerance((double)numPrecursorMassTolerance.Value, (MassToleranceUnits)cboPrecursorMassToleranceUnits.SelectedIndex);
             MassType precursor_mass_type = (MassType)cboPrecursorMassType.SelectedIndex;
-            bool precursor_mono_peak_correction = chkPrecursorMonoisotopicPeakCorrection.Checked;
-            int min_peak_offset = (int)numMinPrecursorMonoPeakOffset.Value;
-            int max_peak_offset = (int)numMaxPrecursorMonoPeakOffset.Value;
+            List<double> massErrors = massErrorsTextBox.Text.Split(',').Select(double.Parse).ToList();
             MassTolerance product_mass_tolerance = new MassTolerance((double)numProductMassTolerance.Value, (MassToleranceUnits)cboProductMassToleranceUnits.SelectedIndex);
             MassType product_mass_type = (MassType)cboProductMassType.SelectedIndex;
             double max_false_discovery_rate = (double)numMaximumFalseDiscoveryRatePercent.Value / 100.0;
@@ -722,7 +676,7 @@ namespace Morpheus
                 protease, max_missed_cleavages, initiator_methionine_behavior,
                 fixed_modifications, variable_modifications, max_variable_mod_isoforms,
                 precursor_mass_tolerance, precursor_mass_type,
-                precursor_mono_peak_correction, min_peak_offset, max_peak_offset,
+                massErrors,
                 product_mass_tolerance, product_mass_type,
                 max_false_discovery_rate, consider_modified_unique,
                 max_threads, minimize_memory_usage,
@@ -909,9 +863,7 @@ namespace Morpheus
                 settings.WriteLine("Precursor Mass Tolerance" + '\t' + numPrecursorMassTolerance.Value.ToString(CultureInfo.InvariantCulture));
                 settings.WriteLine("Precursor Mass Tolerance Units" + '\t' + cboPrecursorMassToleranceUnits.Text);
                 settings.WriteLine("Precursor Mass Type" + '\t' + cboPrecursorMassType.Text);
-                settings.WriteLine("Precursor Monoisotopic Peak Correction" + '\t' + chkPrecursorMonoisotopicPeakCorrection.Checked.ToString().ToLower());
-                settings.WriteLine("Minimum Precursor Offset" + '\t' + ((int)numMinPrecursorMonoPeakOffset.Value).ToString());
-                settings.WriteLine("Maximum Precursor Offset" + '\t' + ((int)numMaxPrecursorMonoPeakOffset.Value).ToString());
+                settings.WriteLine("Mass errors accepted " + massErrorsTextBox.Text);
                 settings.WriteLine("Product Mass Tolerance" + '\t' + numProductMassTolerance.Value.ToString(CultureInfo.InvariantCulture));
                 settings.WriteLine("Product Mass Tolerance Units" + '\t' + cboProductMassToleranceUnits.Text);
                 settings.WriteLine("Product Mass Type" + '\t' + cboProductMassType.Text);


### PR DESCRIPTION
* Automatic output folder selection

* Modification location fix

* Okay

* Add interval search

* cleanup

* more similar to original

* another

* remove monoisotopic peak correction

* restore

* fix form

* rearrange and make similar to removed params

* move label21 back

* remove unused chkMonoisotopicPeakCorrection_CheckedChanged, write mass errors to file

* export mass errors accepted

* slight moving

* add command line option

* Add restoration option

* make names more descriptive, add ResetProgressBar to massErrorsTextBox